### PR TITLE
fix: parquet in map should be capitalized

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,12 +3,12 @@ locals {
 
   compression_map = {
     GZIP    = "GZIP"
-    Parquet = "Parquet"
+    PARQUET = "Parquet"
   }
 
   format_map = {
     TEXT_OR_CSV = "textORcsv"
-    Parquet     = "Parquet"
+    PARQUET     = "Parquet"
   }
 }
 


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Solve

each.value.compression is "PARQUET"
local.compression_map is object with 2 attributes
The given key does not identify an element in this collection value.

each.value.format is "PARQUET"
local.format_map is object with 2 attributes
The given key does not identify an element in this collection value.
